### PR TITLE
feat: fill the order grid Allocated sources column from source reservations

### DIFF
--- a/IOSReservationsAdminUI/Plugin/MagentoInventoryShippingAdminUi/AddReservedSourcesToAllocatedSources.php
+++ b/IOSReservationsAdminUI/Plugin/MagentoInventoryShippingAdminUi/AddReservedSourcesToAllocatedSources.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Copyright © Reach Digital (https://www.reachdigital.io/)
+ * See LICENSE.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace ReachDigital\IOSReservationsAdminUI\Plugin\MagentoInventoryShippingAdminUi;
+
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\InventoryApi\Api\SourceRepositoryInterface;
+use Magento\InventoryShippingAdminUi\Model\ResourceModel\GetAllocatedSourcesForOrder;
+use ReachDigital\IOSReservationsApi\Api\GetOrderSourceReservationsInterface;
+
+/**
+ * Fills the order grid's "Allocated sources" column from source reservations.
+ *
+ * Core only derives allocated sources from shipments
+ * (inventory_shipment_source), so the column stays empty until an order
+ * ships. With order source reservations the allocation is known much
+ * earlier — right after invoicing, when the SSA moves the stock reservation
+ * to sources. When core finds no shipped sources yet, this fills the column
+ * from the order's reservations; once shipments exist, core's answer wins.
+ */
+class AddReservedSourcesToAllocatedSources
+{
+    /** @var GetOrderSourceReservationsInterface */
+    private $getOrderSourceReservations;
+
+    /** @var SourceRepositoryInterface */
+    private $sourceRepository;
+
+    /** @var array<string, string>  source code => display name */
+    private $sourceNames = [];
+
+    public function __construct(
+        GetOrderSourceReservationsInterface $getOrderSourceReservations,
+        SourceRepositoryInterface $sourceRepository
+    ) {
+        $this->getOrderSourceReservations = $getOrderSourceReservations;
+        $this->sourceRepository = $sourceRepository;
+    }
+
+    /**
+     * @param string[] $result
+     * @return string[]
+     */
+    public function afterExecute(GetAllocatedSourcesForOrder $subject, array $result, int $orderId): array
+    {
+        if ($result !== []) {
+            return $result;
+        }
+
+        $reservationResult = $this->getOrderSourceReservations->execute($orderId);
+        if ($reservationResult === null) {
+            return $result;
+        }
+
+        $codes = [];
+        foreach ($reservationResult->getReservationItems() as $item) {
+            $codes[$item->getReservation()->getSourceCode()] = true;
+        }
+
+        return array_values(array_map([$this, 'getSourceName'], array_keys($codes)));
+    }
+
+    private function getSourceName(string $sourceCode): string
+    {
+        if (!isset($this->sourceNames[$sourceCode])) {
+            try {
+                $this->sourceNames[$sourceCode] = (string) $this->sourceRepository->get($sourceCode)->getName();
+            } catch (NoSuchEntityException $e) {
+                $this->sourceNames[$sourceCode] = $sourceCode;
+            }
+        }
+
+        return $this->sourceNames[$sourceCode];
+    }
+}

--- a/IOSReservationsAdminUI/etc/adminhtml/di.xml
+++ b/IOSReservationsAdminUI/etc/adminhtml/di.xml
@@ -14,4 +14,13 @@
                 type="ReachDigital\IOSReservationsAdminUI\Plugin\MagentoSales\ShowSourceReservationOnOrderItem"
                 sortOrder="20"/>
     </type>
+    <!--
+        Fill the order grid's "Allocated sources" column from source
+        reservations when the order has not shipped yet (core only reads
+        inventory_shipment_source).
+    -->
+    <type name="Magento\InventoryShippingAdminUi\Model\ResourceModel\GetAllocatedSourcesForOrder">
+        <plugin name="reachdigital_iosreservations_allocated_sources_from_reservations"
+                type="ReachDigital\IOSReservationsAdminUI\Plugin\MagentoInventoryShippingAdminUi\AddReservedSourcesToAllocatedSources"/>
+    </type>
 </config>


### PR DESCRIPTION
Core's "Allocated sources" order-grid column only reads `inventory_shipment_source`, so it stays empty until an order ships. With order source reservations the allocation is known right after invoicing — this plugin fills the column from the order's reservations whenever core finds no shipped sources, deduplicated and resolved to source names. Once the order ships, core's answer wins unchanged. The grid CSV export uses the same resource model and benefits automatically.

Requested for the Jumbo Sports xCore integration (JSE-151) but generic to any consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)